### PR TITLE
docs: add Blink Skills example page

### DIFF
--- a/docs/examples/blink-skills.md
+++ b/docs/examples/blink-skills.md
@@ -1,0 +1,46 @@
+---
+id: blink-skills
+title: Blink Skills
+slug: /examples/blink-skills
+---
+
+Use Blink Skills to run Lightning wallet operations from agent workflows and scripts.
+
+This repository provides a skill manifest plus self-contained Node.js scripts for common wallet actions like checking balances, creating invoices, paying, pricing, and swaps.
+
+## Screenshot
+
+<img src="https://opengraph.githubassets.com/1/blinkbitcoin/blink-skills" alt="Blink Skills repository preview" width="900"/>
+
+## Quick Start
+
+```bash
+export BLINK_API_KEY="blink_..."
+
+# Optional: use staging/signet for testing
+export BLINK_API_URL="https://api.staging.blink.sv/graphql"
+
+# Balance (includes USD estimate)
+node blink/scripts/balance.js
+
+# Create BTC invoice
+node blink/scripts/create_invoice.js 1000 "Payment"
+
+# Convert sats to USD
+node blink/scripts/price.js 1760
+```
+
+## Typical Use Cases
+* Check wallet balances and account status from scripts.
+* Create and monitor BTC or USD invoices.
+* Send Lightning payments from BTC or USD wallet.
+* Get swap quotes and execute BTC <-> USD conversions.
+* Interact with L402-gated services.
+
+## Links
+### Source Code
+* [github.com/blinkbitcoin/blink-skills](https://github.com/blinkbitcoin/blink-skills)
+
+### More Reading
+* [github.com/blinkbitcoin/blink-skills/blob/main/README.md](https://github.com/blinkbitcoin/blink-skills/blob/main/README.md)
+* [github.com/blinkbitcoin/blink-skills/blob/main/blink/SKILL.md](https://github.com/blinkbitcoin/blink-skills/blob/main/blink/SKILL.md)

--- a/docs/examples/blink-skills.md
+++ b/docs/examples/blink-skills.md
@@ -34,7 +34,7 @@ node blink/scripts/price.js 1760
 * Check wallet balances and account status from scripts.
 * Create and monitor BTC or USD invoices.
 * Send Lightning payments from BTC or USD wallet.
-* Get swap quotes and execute BTC <-> USD conversions.
+* Get swap quotes and execute BTC to USD conversions.
 * Interact with L402-gated services.
 
 ## Links

--- a/sidebars.js
+++ b/sidebars.js
@@ -114,7 +114,8 @@ const sidebars = {
         'examples/btcpayserver-plugin',
         'examples/alby-connector',
         'examples/lnbits-funding-source',
-        'examples/donation-button'
+        'examples/donation-button',
+        'examples/blink-skills'
       ]
     },
   ],


### PR DESCRIPTION
## Summary
- add a new Examples page for blink-skills
- include overview, quick-start commands, and links to README/SKILL docs
- add the page to API Usage Examples in the sidebar

## Testing
- verified sidebar includes examples/blink-skills
- verified new doc frontmatter and content render structure