### PR TITLE
btcpayserver-plugin: document non-custodial (Spark) accounts

### DIFF
--- a/docs/examples/btcpayserver-plugin.md
+++ b/docs/examples/btcpayserver-plugin.md
@@ -7,7 +7,9 @@ slug: /examples/btcpayserver-plugin
 Use Blink as a lightning provider in [BTCPay Server](https://btcpayserver.org).<br />
 Add the default wallet or select between BTC and Stablesats.
 
-Available in BTCPay Server v1.12.0 and later.
+The plugin works with both **custodial** Blink accounts (using an API key) and the new **non-custodial (Spark)** Blink accounts (using your Blink lightning address, for receiving). See [Non-custodial (Spark) account](#non-custodial-spark-account--receive-only) below.
+
+Available in BTCPay Server v1.12.0 and later. Non-custodial (Spark) support requires the Blink plugin v1.1.0 or later.
 
 ## Video Tutorial
 
@@ -81,6 +83,29 @@ If using the USD wallet the requested invoice amount needs to be at least 1 USDc
   is expected as the Blink plugin is connected to a Blink account, not a lightning node directly, but the connection is working.
 
 * Click `Save` to save the connection.
+
+## Non-custodial (Spark) account — receive only
+
+Blink is introducing **non-custodial (Spark)** accounts. These accounts do not expose an API key or a GraphQL wallet id, so the API-key connection described above does not apply to them. Instead, the plugin receives payments through your Blink **lightning address**, and no credentials are required.
+
+* the connection string for a non-custodial account is:
+  ```
+  type=blink;ln-address=yourname@blink.sv;
+  ```
+* a bare username is also accepted and defaults to the `blink.sv` domain, e.g. `type=blink;ln-address=yourname;`
+* `username=` is accepted as an alias for `ln-address=`, e.g. `type=blink;username=yourname@blink.sv;`
+* finalize the connection the same way as above: click `Test connection`, then `Save`.
+
+:::note
+Non-custodial accounts are **receive only**. Creating invoices and receiving payments work; sending, balance and channel operations are not available, because they require the wallet seed, which BTCPay Server never holds. If you need to send from BTCPay Server, use a custodial account (with a `Write`-scoped API key) or another lightning backend.
+:::
+
+* Only **mainnet** (`blink.sv`) is supported for non-custodial accounts.
+* **USDB (non-custodial Dollar balance):** you can add `currency=USD` (`type=blink;ln-address=yourname@blink.sv;currency=USD;`). This is passed through so it works automatically once Blink enables non-custodial USD receiving; until then the connection test reports it as not yet available.
+
+:::note
+Because there is no websocket for non-custodial accounts, the plugin detects settlement by polling. A received payment typically appears in BTCPay Server within a few seconds and up to about a minute.
+:::
 
 ## Enjoy the Benefits of Using Blink
   * instant inbound lightning liquidity


### PR DESCRIPTION
## Summary

The Blink BTCPay Server plugin now supports the new **non-custodial (Spark)** accounts for receiving (shipped in plugin v1.1.0, [Kukks/BTCPayServerPlugins#136](https://github.com/Kukks/BTCPayServerPlugins/pull/136)). The docs page currently only covers the custodial (API-key) setup.

This adds a **"Non-custodial (Spark) account — receive only"** section to `docs/examples/btcpayserver-plugin.md`.

## What's covered

- Connection string: `type=blink;ln-address=yourname@blink.sv;` (no API key / wallet id).
- Bare-username default (`@blink.sv`) and the `username=` alias.
- Receive-only limitation (sending/balance/channels need the wallet seed, which BTCPay never holds).
- Mainnet-only for non-custodial accounts.
- USDB: `currency=USD` pass-through, documented as not yet available server-side.
- Polling-based settlement detection (no websocket for Spark; typically a few seconds up to ~1 minute).
- Intro note that the plugin supports both custodial and non-custodial accounts, with an anchor link to the new section.

The custodial section is unchanged.

## Verification

- Built locally with `yarn build` (Docusaurus 3.3): compiles successfully, no broken-anchor/MDX warnings; the intro anchor resolves to the new section.
- The described non-custodial receive flow has been tested end-to-end against a real non-custodial account (`twentyone@blink.sv`) on production `blink.sv` with a live BTCPay Server v2.4.0 instance.

The wording is adapted from the plugin's own README.