### PR TITLE
docs(pricing): Stablesats conversion spread 0.35% -> 0.50%

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -30,7 +30,7 @@ Robust infrastructure and well-managed Lightning channels allow us to provide th
 
 * Intraledger (between Blink users) – no fee!
 * Outgoing Lightning – only pay routing fees (~0.02%)
-* Stablesats conversion – 0.35% spread, no extra fees
+* Stablesats conversion – 0.50% spread, no extra fees
 * On-chain fee structure:
   * Deposits:
     * For deposits equal to or lower than 1,000,000 sats: 2,500 sats fixed fee


### PR DESCRIPTION
## What

Update the developer-docs pricing line for the Stablesats conversion spread: **0.35% → 0.50%** (`docs/intro.md`).

## Why

The user-facing USD↔BTC spread is being raised 0.35% → 0.50% in [blink-deployments#9921](https://github.com/blinkbitcoin/blink-deployments/pull/9921) (`base_fee_rate` 0.0025 → 0.0040 on the stablesats price-server `FeeCalculator`). This doc hardcodes the number, so it would otherwise go stale on deploy.

## Scope — one line only

```diff
- * Stablesats conversion – 0.35% spread, no extra fees
+ * Stablesats conversion – 0.50% spread, no extra fees
```

